### PR TITLE
update for springboot 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<artifactId>database</artifactId>
 	<packaging>jar</packaging>
-	<version>2.7.0</version>
+	<version>2.7.1</version>
 
 	<name>wily-database</name>
 	<description>Database Configurations for the Wily Framework.</description>
@@ -37,13 +37,13 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 
-		<wily-components.version>2.7.0</wily-components.version>
+		<wily-components.version>2.7.1</wily-components.version>
 	</properties>
 
 	<parent>
 		<groupId>io.csra.wily</groupId>
 		<artifactId>dependencies</artifactId>
-		<version>2.7.0</version>
+		<version>2.7.1</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
Update wily-database version to 2.7.1
Needs wily-components to be deployed first